### PR TITLE
Use standard Ownable2Step ownership

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -5,13 +5,13 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 
-contract LPStaking is ReentrancyGuard, AccessControl {
+contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     using SafeERC20 for IERC20;
 
     // ============ Constants ============
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
-    bytes32 public constant OWNER_APPROVER_ROLE = keccak256("OWNER_APPROVER_ROLE");
     uint256 public constant PRECISION = 1e18;
     uint256 public constant MAX_WEIGHT = 1e21; // weight 1000 precision 1e18
     uint256 public constant MIN_STAKE = 1e15; // 1e15 precision 1e18
@@ -104,13 +104,12 @@ contract LPStaking is ReentrancyGuard, AccessControl {
     event ActionRejected(uint256 actionId, address rejecter);
 
     // ============ Constructor ============
-    constructor(address _rewardToken, address[] memory _initialSigners) {
+    constructor(address _rewardToken, address[] memory _initialSigners) Ownable(msg.sender) {
         require(_initialSigners.length == 4, "Must provide exactly 4 signers");
         require(_rewardToken != address(0), "Invalid reward token address");
         rewardToken = IERC20(_rewardToken);
         signers = _initialSigners;
 
-        _grantRole(OWNER_APPROVER_ROLE, msg.sender);
         for (uint i = 0; i < _initialSigners.length; i++) {
             require(_initialSigners[i] != address(0), "Invalid signer address");
             _grantRole(ADMIN_ROLE, _initialSigners[i]);
@@ -515,8 +514,8 @@ contract LPStaking is ReentrancyGuard, AccessControl {
         PendingAction storage pa = actions[actionId];
         if (pa.actionType == ActionType.CHANGE_SIGNER) {
             require(
-                hasRole(ADMIN_ROLE, msg.sender) || hasRole(OWNER_APPROVER_ROLE, msg.sender),
-                "Caller must have ADMIN_ROLE or OWNER_APPROVER_ROLE"
+                hasRole(ADMIN_ROLE, msg.sender) || msg.sender == owner(),
+                "Caller must have ADMIN_ROLE or owner"
             );
         } else {
             require(hasRole(ADMIN_ROLE, msg.sender), "Caller must have ADMIN_ROLE");

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,7 @@
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-ignition-ethers';
 import '@nomicfoundation/hardhat-verify';
+import '@typechain/hardhat';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/ignition/modules/LPStaking.test.ts
+++ b/ignition/modules/LPStaking.test.ts
@@ -15,7 +15,7 @@ const LPStakingModule = buildModule('LPStakingModule', (m) => {
 
   const lpStaking = m.contract('LPStaking', [libToken, INITIAL_SIGNERS], { id: 'LPStaking' });
 
-  return { libToken, lpStaking };
+  return { lpStaking };
 });
 
 export default LPStakingModule;

--- a/test/Andrey.test.ts
+++ b/test/Andrey.test.ts
@@ -203,7 +203,7 @@ describe("Andrey", function () {
       expect(pair2.isActive).to.be.true;
 
       await expect(
-        lpStaking.connect(user).unstake(lpTokenAddress, STAKE_AMOUNT)
+        lpStaking.connect(user).unstake(lpTokenAddress, STAKE_AMOUNT, false)
       )
         .to.emit(lpStaking, "StakeRemoved")
         .withArgs(user.address, lpTokenAddress, STAKE_AMOUNT);

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -61,6 +61,72 @@ describe('LPStaking', function () {
     ({ lpStaking, rewardToken, lpToken, owner, signers } = await loadFixture(deployBaseFixture));
   });
 
+  describe('Ownership Transfer', function () {
+    it('Should expose the deployer as the standard owner', async function () {
+      expect(await lpStaking.owner()).to.equal(owner.address);
+      expect(await lpStaking.pendingOwner()).to.equal(ethers.ZeroAddress);
+    });
+
+    it('Should transfer ownership through the OpenZeppelin two-step flow', async function () {
+      const newOwner = signers[4];
+
+      await expect(lpStaking.connect(owner).transferOwnership(newOwner.address))
+        .to.emit(lpStaking, 'OwnershipTransferStarted')
+        .withArgs(owner.address, newOwner.address);
+
+      expect(await lpStaking.pendingOwner()).to.equal(newOwner.address);
+
+      await expect(lpStaking.connect(newOwner).acceptOwnership())
+        .to.emit(lpStaking, 'OwnershipTransferred')
+        .withArgs(owner.address, newOwner.address);
+
+      expect(await lpStaking.owner()).to.equal(newOwner.address);
+      expect(await lpStaking.pendingOwner()).to.equal(ethers.ZeroAddress);
+
+      await expect(lpStaking.connect(owner).transferOwnership(signers[5].address))
+        .to.be.revertedWithCustomError(lpStaking, 'OwnableUnauthorizedAccount')
+        .withArgs(owner.address);
+    });
+
+    it('Should use zero address to cancel a pending ownership transfer', async function () {
+      const newOwner = signers[4];
+
+      await lpStaking.connect(owner).transferOwnership(newOwner.address);
+
+      await expect(lpStaking.connect(owner).transferOwnership(ethers.ZeroAddress))
+        .to.emit(lpStaking, 'OwnershipTransferStarted')
+        .withArgs(owner.address, ethers.ZeroAddress);
+
+      expect(await lpStaking.pendingOwner()).to.equal(ethers.ZeroAddress);
+    });
+
+    it('Should reject unauthorized ownership transfer initiators', async function () {
+      const adminOnly = signers[0];
+      const newOwner = signers[4];
+
+      await expect(lpStaking.connect(adminOnly).transferOwnership(newOwner.address))
+        .to.be.revertedWithCustomError(lpStaking, 'OwnableUnauthorizedAccount')
+        .withArgs(adminOnly.address);
+    });
+
+    it('Should reject callers that are not the pending owner', async function () {
+      const newOwner = signers[4];
+      const wrongOwner = signers[5];
+
+      await lpStaking.connect(owner).transferOwnership(newOwner.address);
+
+      await expect(lpStaking.connect(wrongOwner).acceptOwnership())
+        .to.be.revertedWithCustomError(lpStaking, 'OwnableUnauthorizedAccount')
+        .withArgs(wrongOwner.address);
+    });
+
+    it('Should reject acceptance when no owner transfer is pending', async function () {
+      await expect(lpStaking.connect(signers[4]).acceptOwnership())
+        .to.be.revertedWithCustomError(lpStaking, 'OwnableUnauthorizedAccount')
+        .withArgs(signers[4].address);
+    });
+  });
+
   describe('Liquidity Pair Management', function () {
     it('Should add a new liquidity pair', async function () {
       const lpTokenAddress = await lpToken.getAddress();
@@ -385,6 +451,44 @@ describe('LPStaking', function () {
       const ADMIN_ROLE = await lpStaking.ADMIN_ROLE();
       expect(await lpStaking.hasRole(ADMIN_ROLE, newSigner.address)).to.be.true;
       expect(await lpStaking.hasRole(ADMIN_ROLE, oldSigner.address)).to.be.false;
+    });
+
+    it('Should allow the owner to approve signer changes without ADMIN_ROLE', async function () {
+      const allSigners = await ethers.getSigners();
+      const [owner, admin1, admin2, admin3, admin4, replacementSigner] = allSigners;
+
+      const mockERC20 = await ethers.getContractFactory('MockERC20');
+      const rewardToken = await mockERC20.deploy('Liberdus Token', 'LIB');
+      await rewardToken.waitForDeployment();
+
+      const LPStaking = await ethers.getContractFactory('LPStaking');
+      const staking = await LPStaking.deploy(
+        await rewardToken.getAddress(),
+        [admin1.address, admin2.address, admin3.address, admin4.address]
+      ) as LPStaking;
+      await staking.waitForDeployment();
+
+      const ADMIN_ROLE = await staking.ADMIN_ROLE();
+      expect(await staking.hasRole(ADMIN_ROLE, owner.address)).to.be.false;
+
+      const receipt = await (
+        await staking.connect(admin1).proposeChangeSigner(admin4.address, replacementSigner.address)
+      ).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await expect(staking.connect(owner).approveAction(actionId))
+        .to.emit(staking, 'ActionApproved')
+        .withArgs(actionId, owner.address);
+
+      await staking.connect(admin2).approveAction(actionId);
+
+      await expect(staking.connect(admin1).executeAction(actionId))
+        .to.emit(staking, 'SignerChanged')
+        .withArgs(admin4.address, replacementSigner.address);
+
+      expect(await staking.hasRole(ADMIN_ROLE, replacementSigner.address)).to.be.true;
+      expect(await staking.hasRole(ADMIN_ROLE, admin4.address)).to.be.false;
     });
 
     it('Should withdraw rewards', async function () {


### PR DESCRIPTION
## Summary

- Replace the custom `OWNER_APPROVER_ROLE` ownership path with OpenZeppelin `Ownable2Step`.
- Allow the standard owner to approve signer-change actions alongside admins.
- Add ownership transfer tests for the standard two-step flow, cancellation, and unauthorized callers.
- Enable TypeChain generation in Hardhat config and clean up TypeScript issues in tests/Ignition module.

Closes #10.

## Validation

- `npx hardhat test --network hardhat --typecheck`