### PR TITLE
Add recipient-aware unstake and claim flows

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -88,7 +88,9 @@ contract LPStaking is ReentrancyGuard, AccessControl {
     event PairRemoved(address lpToken, string pairName);
     event StakeAdded(address user, address lpToken, uint256 amount);
     event StakeRemoved(address user, address lpToken, uint256 amount);
+    event StakeRemovedTo(address indexed user, address indexed receiver, address indexed lpToken, uint256 amount);
     event RewardsClaimed(address user, address lpToken, uint256 amount);
+    event RewardsClaimedTo(address indexed user, address indexed receiver, address indexed lpToken, uint256 amount);
     event HourlyRateUpdated(uint256 newRate);
     event WeightsUpdated(address[] pairs, uint256[] weights);
     event SignerChanged(address oldSigner, address newSigner);
@@ -145,7 +147,7 @@ contract LPStaking is ReentrancyGuard, AccessControl {
         address user,
         address lpToken
     ) public view returns (uint256) {
-        UserStake storage stake = userStakes[user][lpToken];
+        UserStake storage storedStake = userStakes[user][lpToken];
         uint256 currentRewardPerToken = rewardPerTokenStored[lpToken];
 
         if (
@@ -164,10 +166,10 @@ contract LPStaking is ReentrancyGuard, AccessControl {
         }
 
         return
-            (stake.amount *
-                (currentRewardPerToken - stake.rewardPerTokenPaid)) /
+            (storedStake.amount *
+                (currentRewardPerToken - storedStake.rewardPerTokenPaid)) /
             PRECISION +
-            stake.pendingRewards;
+            storedStake.pendingRewards;
     }
 
     function getPairInfo(
@@ -194,8 +196,8 @@ contract LPStaking is ReentrancyGuard, AccessControl {
         view
         returns (uint256 amount, uint256 pendingRewards, uint256 lastRewardTime)
     {
-        UserStake storage stake = userStakes[user][lpToken];
-        return (stake.amount, earned(user, lpToken), stake.lastRewardTime);
+        UserStake storage storedStake = userStakes[user][lpToken];
+        return (storedStake.amount, earned(user, lpToken), storedStake.lastRewardTime);
     }
 
     function getActivePairs() external view returns (address[] memory) {
@@ -285,56 +287,26 @@ contract LPStaking is ReentrancyGuard, AccessControl {
     function unstake(
         address lpToken,
         uint256 amount,
-        bool claimRewards
+        bool shouldClaimRewards
     ) external nonReentrant {
-        LiquidityPair storage pair = pairs[lpToken];
-        require(pair.isActive, "Pair not active");
+        _unstake(lpToken, amount, shouldClaimRewards, msg.sender);
+    }
 
-        UserStake storage userStake = userStakes[msg.sender][lpToken];
-        require(userStake.amount >= amount, "Insufficient stake");
-
-        updateRewardPerToken(lpToken);
-        uint256 rewards = earned(msg.sender, lpToken);
-        if (amount == userStake.amount) {
-            userStake.amount = 0;
-        } else {
-            userStake.amount -= amount;
-        }
-
-        userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
-        if (claimRewards && rewards > 0) {
-            userStake.pendingRewards = 0;
-        } else {
-            userStake.pendingRewards = rewards;
-        }
-
-        IERC20(lpToken).safeTransfer(msg.sender, amount);
-
-        emit StakeRemoved(msg.sender, lpToken, amount);
-        if (claimRewards && rewards > 0) {
-            require(rewardToken.balanceOf(address(this)) >= rewards, "Insufficient reward balance");
-            totalRewardsObligated -= rewards;
-            rewardToken.safeTransfer(msg.sender, rewards);
-            emit RewardsClaimed(msg.sender, lpToken, rewards);
-        }
+    function unstakeTo(
+        address lpToken,
+        uint256 amount,
+        bool shouldClaimRewards,
+        address receiver
+    ) external nonReentrant {
+        _unstake(lpToken, amount, shouldClaimRewards, receiver);
     }
 
     function claimRewards(address lpToken) external nonReentrant {
-        LiquidityPair storage pair = pairs[lpToken];
-        require(pair.isActive, "Pair not active");
+        _claimRewards(lpToken, msg.sender);
+    }
 
-        updateRewardPerToken(lpToken);
-        uint256 rewards = earned(msg.sender, lpToken);
-        require(rewards > 0, "No rewards to claim");
-
-        UserStake storage userStake = userStakes[msg.sender][lpToken];
-        userStake.pendingRewards = 0;
-        userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
-
-        require(rewardToken.balanceOf(address(this)) >= rewards, "Insufficient reward balance");
-        totalRewardsObligated -= rewards;
-        rewardToken.safeTransfer(msg.sender, rewards);
-        emit RewardsClaimed(msg.sender, lpToken, rewards);
+    function claimRewardsTo(address lpToken, address receiver) external nonReentrant {
+        _claimRewards(lpToken, receiver);
     }
 
     // ============ Admin Actions ============
@@ -652,6 +624,69 @@ contract LPStaking is ReentrancyGuard, AccessControl {
     }
 
     // ============ Internal Functions ============
+    function _unstake(
+        address lpToken,
+        uint256 amount,
+        bool shouldClaimRewards,
+        address receiver
+    ) internal {
+        require(receiver != address(0), "Invalid receiver");
+
+        LiquidityPair storage pair = pairs[lpToken];
+        require(pair.isActive, "Pair not active");
+
+        UserStake storage userStake = userStakes[msg.sender][lpToken];
+        require(userStake.amount >= amount, "Insufficient stake");
+
+        updateRewardPerToken(lpToken);
+        uint256 rewards = earned(msg.sender, lpToken);
+        if (amount == userStake.amount) {
+            userStake.amount = 0;
+        } else {
+            userStake.amount -= amount;
+        }
+
+        userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
+        if (shouldClaimRewards && rewards > 0) {
+            userStake.pendingRewards = 0;
+        } else {
+            userStake.pendingRewards = rewards;
+        }
+
+        IERC20(lpToken).safeTransfer(receiver, amount);
+
+        emit StakeRemoved(msg.sender, lpToken, amount);
+        emit StakeRemovedTo(msg.sender, receiver, lpToken, amount);
+        if (shouldClaimRewards && rewards > 0) {
+            require(rewardToken.balanceOf(address(this)) >= rewards, "Insufficient reward balance");
+            totalRewardsObligated -= rewards;
+            rewardToken.safeTransfer(receiver, rewards);
+            emit RewardsClaimed(msg.sender, lpToken, rewards);
+            emit RewardsClaimedTo(msg.sender, receiver, lpToken, rewards);
+        }
+    }
+
+    function _claimRewards(address lpToken, address receiver) internal {
+        require(receiver != address(0), "Invalid receiver");
+
+        LiquidityPair storage pair = pairs[lpToken];
+        require(pair.isActive, "Pair not active");
+
+        updateRewardPerToken(lpToken);
+        uint256 rewards = earned(msg.sender, lpToken);
+        require(rewards > 0, "No rewards to claim");
+
+        UserStake storage userStake = userStakes[msg.sender][lpToken];
+        userStake.pendingRewards = 0;
+        userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
+
+        require(rewardToken.balanceOf(address(this)) >= rewards, "Insufficient reward balance");
+        totalRewardsObligated -= rewards;
+        rewardToken.safeTransfer(receiver, rewards);
+        emit RewardsClaimed(msg.sender, lpToken, rewards);
+        emit RewardsClaimedTo(msg.sender, receiver, lpToken, rewards);
+    }
+
     function updateAllRewards() internal {
         for (uint i = 0; i < activePairs.length; i++) {
             address lpToken = activePairs[i];

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,7 @@
 import { HardhatUserConfig } from 'hardhat/config';
 import '@nomicfoundation/hardhat-ignition-ethers';
 import '@nomicfoundation/hardhat-verify';
+import '@typechain/hardhat';
 import dotenv from 'dotenv';
 dotenv.config();
 

--- a/ignition/modules/LPStaking.test.ts
+++ b/ignition/modules/LPStaking.test.ts
@@ -15,7 +15,7 @@ const LPStakingModule = buildModule('LPStakingModule', (m) => {
 
   const lpStaking = m.contract('LPStaking', [libToken, INITIAL_SIGNERS], { id: 'LPStaking' });
 
-  return { libToken, lpStaking };
+  return { lpStaking };
 });
 
 export default LPStakingModule;

--- a/test/Andrey.test.ts
+++ b/test/Andrey.test.ts
@@ -203,7 +203,7 @@ describe("Andrey", function () {
       expect(pair2.isActive).to.be.true;
 
       await expect(
-        lpStaking.connect(user).unstake(lpTokenAddress, STAKE_AMOUNT)
+        lpStaking.connect(user).unstake(lpTokenAddress, STAKE_AMOUNT, false)
       )
         .to.emit(lpStaking, "StakeRemoved")
         .withArgs(user.address, lpTokenAddress, STAKE_AMOUNT);

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -4,6 +4,7 @@ import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { LPStaking, MockERC20 } from '../typechain-types';
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers';
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 
 describe('LPStaking', function () {
   let lpStaking: LPStaking;
@@ -55,6 +56,37 @@ describe('LPStaking', function () {
     // Add pair and set rate
     await proposeAndExecute(lpStaking.proposeAddPair(lpTokenAddress, 'LIB-USDT', 'Uniswap-V2', ethers.parseEther('7')));
     await proposeAndExecute(lpStaking.proposeSetHourlyRewardRate(HOURLY_REWARD));
+  }
+
+  async function setupPairOnly(lpStaking: LPStaking, lpTokenAddress: string, signers: SignerWithAddress[]) {
+    const receipt = await (
+      await lpStaking.proposeAddPair(lpTokenAddress, 'LIB-USDT', 'Uniswap-V2', ethers.parseEther('7'))
+    ).wait();
+    const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+    const actionId = (event as any)?.args?.actionId;
+
+    for (let i = 0; i < 2; i++) {
+      await lpStaking.connect(signers[i]).approveAction(Number(actionId));
+    }
+    await lpStaking.executeAction(Number(actionId));
+    return actionId;
+  }
+
+  async function deployUnderfundedStakedFixture() {
+    const { lpStaking, lpToken, signers } = await deployBaseFixture();
+    const lpTokenAddress = await lpToken.getAddress();
+    const staker = signers[4];
+    const receiver = signers[5];
+
+    await lpToken.mint(staker.address, INITIAL_BALANCE);
+    await lpToken.connect(staker).approve(await lpStaking.getAddress(), INITIAL_BALANCE);
+    await setupPairAndRate(lpStaking, lpTokenAddress, signers);
+    await lpStaking.connect(staker).stake(lpTokenAddress, STAKE_AMOUNT);
+
+    await ethers.provider.send('evm_increaseTime', [3600]);
+    await ethers.provider.send('evm_mine', []);
+
+    return { lpStaking, lpTokenAddress, staker, receiver };
   }
 
   beforeEach(async function () {
@@ -192,6 +224,202 @@ describe('LPStaking', function () {
       const finalBalance = await lpToken.balanceOf(user1.address);
       
       expect(finalBalance - initialBalance).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should allow partial unstaking LP tokens to a different receiver', async function () {
+      const receiver = signers[0];
+      const partialAmount = STAKE_AMOUNT / 2n;
+      const initialUserBalance = await lpToken.balanceOf(user1.address);
+      const initialReceiverBalance = await lpToken.balanceOf(receiver.address);
+
+      const tx = await lpStaking.connect(user1).unstakeTo(
+        lpTokenAddress,
+        partialAmount,
+        false,
+        receiver.address
+      );
+
+      await expect(tx)
+        .to.emit(lpStaking, 'StakeRemoved')
+        .withArgs(user1.address, lpTokenAddress, partialAmount);
+      await expect(tx)
+        .to.emit(lpStaking, 'StakeRemovedTo')
+        .withArgs(user1.address, receiver.address, lpTokenAddress, partialAmount);
+
+      const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
+      expect(userStake.amount).to.equal(STAKE_AMOUNT - partialAmount);
+      expect(await lpToken.balanceOf(user1.address)).to.equal(initialUserBalance);
+      expect(await lpToken.balanceOf(receiver.address)).to.equal(initialReceiverBalance + partialAmount);
+    });
+
+    it('Should allow full unstaking LP tokens to a different receiver', async function () {
+      const receiver = signers[0];
+      const initialReceiverBalance = await lpToken.balanceOf(receiver.address);
+
+      await expect(
+        lpStaking.connect(user1).unstakeTo(lpTokenAddress, STAKE_AMOUNT, false, receiver.address)
+      )
+        .to.emit(lpStaking, 'StakeRemovedTo')
+        .withArgs(user1.address, receiver.address, lpTokenAddress, STAKE_AMOUNT);
+
+      const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
+      expect(userStake.amount).to.equal(0);
+      expect(await lpToken.balanceOf(receiver.address)).to.equal(initialReceiverBalance + STAKE_AMOUNT);
+    });
+
+    it('Should allow unstaking to a receiver and claiming rewards to the same receiver', async function () {
+      const receiver = signers[0];
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialReceiverLpBalance = await lpToken.balanceOf(receiver.address);
+      const initialReceiverRewardBalance = await rewardToken.balanceOf(receiver.address);
+      const initialUserRewardBalance = await rewardToken.balanceOf(user1.address);
+
+      const tx = await lpStaking.connect(user1).unstakeTo(
+        lpTokenAddress,
+        STAKE_AMOUNT,
+        true,
+        receiver.address
+      );
+
+      await expect(tx)
+        .to.emit(lpStaking, 'StakeRemovedTo')
+        .withArgs(user1.address, receiver.address, lpTokenAddress, STAKE_AMOUNT);
+      await expect(tx)
+        .to.emit(lpStaking, 'RewardsClaimedTo')
+        .withArgs(user1.address, receiver.address, lpTokenAddress, anyValue);
+
+      const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
+      expect(userStake.amount).to.equal(0);
+      expect(userStake.pendingRewards).to.equal(0);
+      expect(await lpToken.balanceOf(receiver.address)).to.equal(initialReceiverLpBalance + STAKE_AMOUNT);
+      expect(await rewardToken.balanceOf(receiver.address)).to.be.gt(initialReceiverRewardBalance);
+      expect(await rewardToken.balanceOf(user1.address)).to.equal(initialUserRewardBalance);
+    });
+
+    it('Should allow unstaking to a receiver with claim enabled when no rewards accrued', async function () {
+      const {
+        lpStaking: zeroRateStaking,
+        rewardToken: zeroRateRewardToken,
+        lpToken: zeroRateLpToken,
+        signers: zeroRateSigners
+      } = await deployBaseFixture();
+      const zeroRateLpTokenAddress = await zeroRateLpToken.getAddress();
+      const staker = zeroRateSigners[4];
+      const receiver = zeroRateSigners[5];
+
+      await zeroRateLpToken.mint(staker.address, INITIAL_BALANCE);
+      await zeroRateLpToken.connect(staker).approve(await zeroRateStaking.getAddress(), INITIAL_BALANCE);
+      await setupPairOnly(zeroRateStaking, zeroRateLpTokenAddress, zeroRateSigners);
+      await zeroRateStaking.connect(staker).stake(zeroRateLpTokenAddress, STAKE_AMOUNT);
+
+      const initialReceiverRewardBalance = await zeroRateRewardToken.balanceOf(receiver.address);
+
+      const tx = await zeroRateStaking.connect(staker).unstakeTo(
+        zeroRateLpTokenAddress,
+        STAKE_AMOUNT,
+        true,
+        receiver.address
+      );
+
+      await expect(tx)
+        .to.emit(zeroRateStaking, 'StakeRemovedTo')
+        .withArgs(staker.address, receiver.address, zeroRateLpTokenAddress, STAKE_AMOUNT);
+      await expect(tx).to.not.emit(zeroRateStaking, 'RewardsClaimedTo');
+
+      const userStake = await zeroRateStaking.getUserStakeInfo(staker.address, zeroRateLpTokenAddress);
+      expect(userStake.amount).to.equal(0);
+      expect(userStake.pendingRewards).to.equal(0);
+      expect(await zeroRateRewardToken.balanceOf(receiver.address)).to.equal(initialReceiverRewardBalance);
+    });
+
+    it('Should allow unstaking to a receiver without claiming rewards', async function () {
+      const receiver = signers[0];
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialReceiverRewardBalance = await rewardToken.balanceOf(receiver.address);
+
+      await lpStaking.connect(user1).unstakeTo(lpTokenAddress, STAKE_AMOUNT, false, receiver.address);
+
+      const userStake = await lpStaking.userStakes(user1.address, lpTokenAddress);
+      expect(userStake.amount).to.equal(0);
+      expect(userStake.pendingRewards).to.be.gt(0);
+      expect(await rewardToken.balanceOf(receiver.address)).to.equal(initialReceiverRewardBalance);
+    });
+
+    it('Should allow claiming rewards to a different receiver', async function () {
+      const receiver = signers[0];
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialReceiverRewardBalance = await rewardToken.balanceOf(receiver.address);
+      const initialUserRewardBalance = await rewardToken.balanceOf(user1.address);
+
+      const tx = await lpStaking.connect(user1).claimRewardsTo(lpTokenAddress, receiver.address);
+
+      await expect(tx)
+        .to.emit(lpStaking, 'RewardsClaimedTo')
+        .withArgs(user1.address, receiver.address, lpTokenAddress, anyValue);
+
+      const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
+      expect(userStake.pendingRewards).to.equal(0);
+      expect(await rewardToken.balanceOf(receiver.address)).to.be.gt(initialReceiverRewardBalance);
+      expect(await rewardToken.balanceOf(user1.address)).to.equal(initialUserRewardBalance);
+    });
+
+    it('Should reject recipient-aware unstake and claim for inactive pairs', async function () {
+      const receiver = signers[0];
+      const mockToken = await ethers.deployContract('MockERC20', ['Mock LP', 'MLP']);
+      const inactiveLpTokenAddress = await mockToken.getAddress();
+
+      await expect(
+        lpStaking.connect(user1).unstakeTo(inactiveLpTokenAddress, STAKE_AMOUNT, false, receiver.address)
+      ).to.be.revertedWith('Pair not active');
+
+      await expect(
+        lpStaking.connect(user1).claimRewardsTo(inactiveLpTokenAddress, receiver.address)
+      ).to.be.revertedWith('Pair not active');
+    });
+
+    it('Should reject unstaking with rewards to a receiver when reward balance is insufficient', async function () {
+      const { lpStaking, lpTokenAddress, staker, receiver } = await deployUnderfundedStakedFixture();
+
+      await expect(
+        lpStaking.connect(staker).unstakeTo(lpTokenAddress, STAKE_AMOUNT, true, receiver.address)
+      ).to.be.revertedWith('Insufficient reward balance');
+    });
+
+    it('Should reject claiming rewards to a receiver when reward balance is insufficient', async function () {
+      const { lpStaking, lpTokenAddress, staker, receiver } = await deployUnderfundedStakedFixture();
+
+      await expect(
+        lpStaking.connect(staker).claimRewardsTo(lpTokenAddress, receiver.address)
+      ).to.be.revertedWith('Insufficient reward balance');
+    });
+
+    it('Should reject zero receivers for recipient-aware unstake and claim', async function () {
+      await expect(
+        lpStaking.connect(user1).unstakeTo(lpTokenAddress, STAKE_AMOUNT, false, ethers.ZeroAddress)
+      ).to.be.revertedWith('Invalid receiver');
+
+      await expect(
+        lpStaking.connect(user1).claimRewardsTo(lpTokenAddress, ethers.ZeroAddress)
+      ).to.be.revertedWith('Invalid receiver');
+    });
+
+    it('Should not allow another account to unstake or claim a user stake', async function () {
+      const receiver = signers[1];
+      const nonStaker = signers[0];
+
+      await expect(
+        lpStaking.connect(nonStaker).unstakeTo(lpTokenAddress, STAKE_AMOUNT, false, receiver.address)
+      ).to.be.revertedWith('Insufficient stake');
+
+      await expect(
+        lpStaking.connect(nonStaker).claimRewardsTo(lpTokenAddress, receiver.address)
+      ).to.be.revertedWith('No rewards to claim');
     });
 
     it('Should allow unstaking without claiming rewards and keep them pending', async function () {


### PR DESCRIPTION
## Summary

- Add `unstakeTo` and `claimRewardsTo` recipient-aware user flows while keeping existing `unstake` and `claimRewards` wrappers intact.
- Emit recipient-aware events alongside the existing stake/reward events so both the stake owner and receiver are explicit.
- Refactor unstake and claim accounting through shared internal helpers.
- Add tests for partial/full recipient unstake, reward forwarding, no-reward claim branch, inactive pairs, insufficient reward funding, zero receivers, and no-stake callers.
- Enable TypeChain generation and fix the Ignition test module return type so typed checks pass.

Closes #11.

## Validation

- `npx tsc --noEmit`
- `npx hardhat test --network hardhat --typecheck`