### PR TITLE
Harden staking governance

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -84,6 +84,8 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     uint256 public totalWeight;
     uint256 public actionCounter;
     uint256 public totalRewardsObligated;
+    uint256 public pendingActionCount;
+    uint256 public pendingChangeSignerActionId;
     mapping(uint256 => PendingAction) public actions;
 
     // ============ Events ============
@@ -328,17 +330,20 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         PendingAction storage pa = actions[actionId];
         require(!pa.executed, "Action already executed");
         require(!pa.expired, "Action already marked expired");
+        require(!pa.rejected, "Action was rejected");
         require(isActionExpired(actionId), "Action not expired yet");
 
         pa.expired = true;
+        _closePendingAction(actionId);
         emit ActionExpired(actionId);
     }
 
     function cleanupExpiredActions() external onlyRole(ADMIN_ROLE) {
         for (uint256 i = 1; i <= actionCounter; i++) {
             PendingAction storage pa = actions[i];
-            if (!pa.executed && !pa.expired && isActionExpired(i)) {
+            if (!pa.executed && !pa.expired && !pa.rejected && isActionExpired(i)) {
                 pa.expired = true;
+                _closePendingAction(i);
                 emit ActionExpired(i);
             }
         }
@@ -355,6 +360,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             "Amount exceeds contract balance"
         );
         require(amount <= type(uint128).max, "Amount too large");
+        _requireCanPropose(ActionType.WITHDRAW_REWARDS);
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -368,6 +374,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             msg.sender,
             ActionType.WITHDRAW_REWARDS
         );
+        _openPendingAction(actionCounter);
         _approveActionInternal(actionCounter);
         return actionCounter;
     }
@@ -376,6 +383,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         uint256 newRate
     ) external onlyRole(ADMIN_ROLE) returns (uint256) {
         require(newRate <= type(uint128).max, "Rate too high");
+        _requireCanPropose(ActionType.SET_HOURLY_REWARD_RATE);
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -388,6 +396,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             msg.sender,
             ActionType.SET_HOURLY_REWARD_RATE
         );
+        _openPendingAction(actionCounter);
         _approveActionInternal(actionCounter);
         return actionCounter;
     }
@@ -404,6 +413,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             require(weights[i] <= MAX_WEIGHT, "Weight exceeds maximum");
             require(lpTokens[i] != address(0), "Invalid LP token address");
         }
+        _requireCanPropose(ActionType.UPDATE_PAIR_WEIGHTS);
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -417,6 +427,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             msg.sender,
             ActionType.UPDATE_PAIR_WEIGHTS
         );
+        _openPendingAction(actionCounter);
         _approveActionInternal(actionCounter);
         return actionCounter;
     }
@@ -434,6 +445,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(bytes(pairName).length <= 32, "Pair name too long");
         require(bytes(platform).length > 0, "Empty platform name");
         require(bytes(platform).length <= 32, "Platform name too long");
+        _requireCanPropose(ActionType.ADD_PAIR);
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -445,6 +457,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         pa.proposedTime = block.timestamp;
 
         emit ActionProposed(actionCounter, msg.sender, ActionType.ADD_PAIR);
+        _openPendingAction(actionCounter);
         _approveActionInternal(actionCounter);
         return actionCounter;
     }
@@ -454,6 +467,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     ) external onlyRole(ADMIN_ROLE) returns (uint256) {
         require(lpToken != address(0), "Invalid pair address");
         require(pairs[lpToken].isActive, "Pair not active or doesn't exist");
+        _requireCanPropose(ActionType.REMOVE_PAIR);
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -463,6 +477,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         pa.pairNameToAdd = pairs[lpToken].pairName; // Reusing field for event info
 
         emit ActionProposed(actionCounter, msg.sender, ActionType.REMOVE_PAIR);
+        _openPendingAction(actionCounter);
         _approveActionInternal(actionCounter);
         return actionCounter;
     }
@@ -474,6 +489,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(hasRole(ADMIN_ROLE, oldSigner), "Old signer not found");
         require(!hasRole(ADMIN_ROLE, newSigner), "New signer already exists");
         require(newSigner != address(0), "Invalid new signer");
+        _requireCanPropose(ActionType.CHANGE_SIGNER);
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -487,6 +503,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             msg.sender,
             ActionType.CHANGE_SIGNER
         );
+        _openPendingAction(actionCounter);
         _approveActionInternal(actionCounter);
         return actionCounter;
     }
@@ -614,6 +631,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         }
 
         pa.executed = true;
+        _closePendingAction(actionId);
         emit ActionExecuted(actionId);
     }
 
@@ -644,6 +662,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
 
         if (pa.rejections >= REQUIRED_REJECTIONS) {
             pa.rejected = true;
+            _closePendingAction(actionId);
         }
 
         emit ActionRejected(actionId, msg.sender);
@@ -746,6 +765,33 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         userStake.pendingRewards = earned(user, lpToken);
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
         userStake.lastRewardTime = uint64(block.timestamp);
+    }
+
+    function _requireCanPropose(ActionType actionType) internal view {
+        if (actionType == ActionType.CHANGE_SIGNER) {
+            require(pendingActionCount == 0, "Pending action exists");
+        } else {
+            require(
+                pendingChangeSignerActionId == 0,
+                "Pending signer change exists"
+            );
+        }
+    }
+
+    function _openPendingAction(uint256 actionId) internal {
+        pendingActionCount++;
+        if (actions[actionId].actionType == ActionType.CHANGE_SIGNER) {
+            pendingChangeSignerActionId = actionId;
+        }
+    }
+
+    function _closePendingAction(uint256 actionId) internal {
+        if (pendingActionCount > 0) {
+            pendingActionCount--;
+        }
+        if (pendingChangeSignerActionId == actionId) {
+            pendingChangeSignerActionId = 0;
+        }
     }
 
     function _approveActionInternal(uint256 actionId) internal {

--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -17,7 +17,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     uint256 public constant MIN_STAKE = 1e15; // 1e15 precision 1e18
     uint256 public constant MAX_PAIRS = 100;
     uint256 public constant REQUIRED_APPROVALS = 3;
-    uint256 public constant REQUIRED_REJECTIONS = 3;
+    uint256 public constant REQUIRED_REJECTIONS = 2;
     uint256 private constant SECONDS_PER_HOUR = 3600;
     uint256 private constant ACTION_EXPIRY = 7 days; // Actions expire after 7 days
 
@@ -360,7 +360,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             "Amount exceeds contract balance"
         );
         require(amount <= type(uint128).max, "Amount too large");
-        _requireCanPropose(ActionType.WITHDRAW_REWARDS);
+        _requireCanPropose();
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -383,7 +383,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         uint256 newRate
     ) external onlyRole(ADMIN_ROLE) returns (uint256) {
         require(newRate <= type(uint128).max, "Rate too high");
-        _requireCanPropose(ActionType.SET_HOURLY_REWARD_RATE);
+        _requireCanPropose();
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -413,7 +413,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             require(weights[i] <= MAX_WEIGHT, "Weight exceeds maximum");
             require(lpTokens[i] != address(0), "Invalid LP token address");
         }
-        _requireCanPropose(ActionType.UPDATE_PAIR_WEIGHTS);
+        _requireCanPropose();
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -445,7 +445,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(bytes(pairName).length <= 32, "Pair name too long");
         require(bytes(platform).length > 0, "Empty platform name");
         require(bytes(platform).length <= 32, "Platform name too long");
-        _requireCanPropose(ActionType.ADD_PAIR);
+        _requireCanPropose();
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -467,7 +467,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     ) external onlyRole(ADMIN_ROLE) returns (uint256) {
         require(lpToken != address(0), "Invalid pair address");
         require(pairs[lpToken].isActive, "Pair not active or doesn't exist");
-        _requireCanPropose(ActionType.REMOVE_PAIR);
+        _requireCanPropose();
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -489,7 +489,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(hasRole(ADMIN_ROLE, oldSigner), "Old signer not found");
         require(!hasRole(ADMIN_ROLE, newSigner), "New signer already exists");
         require(newSigner != address(0), "Invalid new signer");
-        _requireCanPropose(ActionType.CHANGE_SIGNER);
+        _requireCanPropose();
 
         actionCounter++;
         PendingAction storage pa = actions[actionCounter];
@@ -767,15 +767,8 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         userStake.lastRewardTime = uint64(block.timestamp);
     }
 
-    function _requireCanPropose(ActionType actionType) internal view {
-        if (actionType == ActionType.CHANGE_SIGNER) {
-            require(pendingActionCount == 0, "Pending action exists");
-        } else {
-            require(
-                pendingChangeSignerActionId == 0,
-                "Pending signer change exists"
-            );
-        }
+    function _requireCanPropose() internal view {
+        require(pendingActionCount == 0, "Pending action exists");
     }
 
     function _openPendingAction(uint256 actionId) internal {

--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -17,6 +17,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     uint256 public constant MIN_STAKE = 1e15; // 1e15 precision 1e18
     uint256 public constant MAX_PAIRS = 100;
     uint256 public constant REQUIRED_APPROVALS = 3;
+    uint256 public constant REQUIRED_REJECTIONS = 3;
     uint256 private constant SECONDS_PER_HOUR = 3600;
     uint256 private constant ACTION_EXPIRY = 7 days; // Actions expire after 7 days
 
@@ -61,7 +62,9 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         bool executed;
         bool expired;
         uint8 approvals;
+        uint8 rejections;
         address[] approvedBy;
+        address[] rejectedBy;
         uint256 proposedTime; // Timestamp when action was proposed
         bool rejected;
     }
@@ -114,6 +117,9 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
 
         for (uint i = 0; i < _initialSigners.length; i++) {
             require(_initialSigners[i] != address(0), "Invalid signer address");
+            for (uint j = i + 1; j < _initialSigners.length; j++) {
+                require(_initialSigners[i] != _initialSigners[j], "Duplicate signer");
+            }
             _grantRole(ADMIN_ROLE, _initialSigners[i]);
         }
     }
@@ -135,6 +141,12 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         uint256 actionId
     ) external view returns (address[] memory) {
         return actions[actionId].approvedBy;
+    }
+
+    function getActionRejection(
+        uint256 actionId
+    ) external view returns (address[] memory) {
+        return actions[actionId].rejectedBy;
     }
 
     function isActionExpired(uint256 actionId) public view returns (bool) {
@@ -495,6 +507,11 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         _approveActionInternal(actionId);
     }
 
+    function renounceRole(bytes32 role, address callerConfirmation) public override {
+        require(role != ADMIN_ROLE, "ADMIN_ROLE cannot be renounced");
+        super.renounceRole(role, callerConfirmation);
+    }
+
     function executeAction(uint256 actionId) external onlyRole(ADMIN_ROLE) {
         require(actionId > 0 && actionId <= actionCounter, "Invalid actionId");
         PendingAction storage pa = actions[actionId];
@@ -618,7 +635,17 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             );
         }
 
-        pa.rejected = true;
+        for (uint i = 0; i < pa.rejectedBy.length; i++) {
+            require(pa.rejectedBy[i] != msg.sender, "Already rejected");
+        }
+
+        pa.rejectedBy.push(msg.sender);
+        pa.rejections++;
+
+        if (pa.rejections >= REQUIRED_REJECTIONS) {
+            pa.rejected = true;
+        }
+
         emit ActionRejected(actionId, msg.sender);
     }
 
@@ -734,6 +761,10 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         // Check if already approved
         for (uint i = 0; i < pa.approvedBy.length; i++) {
             require(pa.approvedBy[i] != msg.sender, "Already approved");
+        }
+
+        for (uint i = 0; i < pa.rejectedBy.length; i++) {
+            require(pa.rejectedBy[i] != msg.sender, "Cannot approve after rejecting");
         }
 
         pa.approvedBy.push(msg.sender);

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -818,6 +818,91 @@ describe('LPStaking', function () {
       await expect(lpStaking.connect(owner).renounceRole(ADMIN_ROLE, owner.address))
         .to.be.revertedWith('ADMIN_ROLE cannot be renounced');
     });
+
+    it('Should block signer changes while a normal action is pending', async function () {
+      const oldSigner = signers[0];
+      const replacementSigner = signers[4];
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      expect(await lpStaking.pendingActionCount()).to.equal(1);
+
+      await expect(
+        lpStaking.proposeChangeSigner(oldSigner.address, replacementSigner.address)
+      ).to.be.revertedWith('Pending action exists');
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+      await lpStaking.connect(signers[1]).approveAction(actionId);
+      await lpStaking.executeAction(actionId);
+
+      expect(await lpStaking.pendingActionCount()).to.equal(0);
+
+      await expect(lpStaking.proposeChangeSigner(oldSigner.address, replacementSigner.address))
+        .to.emit(lpStaking, 'ActionProposed');
+    });
+
+    it('Should block normal actions and additional signer changes while a signer change is pending', async function () {
+      const oldSigner = signers[0];
+      const replacementSigner = signers[4];
+      const receipt = await (
+        await lpStaking.proposeChangeSigner(oldSigner.address, replacementSigner.address)
+      ).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      expect(await lpStaking.pendingActionCount()).to.equal(1);
+      expect(await lpStaking.pendingChangeSignerActionId()).to.equal(actionId);
+
+      await expect(lpStaking.proposeSetHourlyRewardRate(NEW_RATE))
+        .to.be.revertedWith('Pending signer change exists');
+
+      await expect(
+        lpStaking.proposeChangeSigner(signers[1].address, signers[5].address)
+      ).to.be.revertedWith('Pending action exists');
+    });
+
+    it('Should unblock proposals after a pending action is rejected', async function () {
+      const oldSigner = signers[0];
+      const replacementSigner = signers[4];
+      const receipt = await (
+        await lpStaking.proposeChangeSigner(oldSigner.address, replacementSigner.address)
+      ).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(signers[0]).rejectAction(actionId);
+      await lpStaking.connect(signers[1]).rejectAction(actionId);
+      await lpStaking.connect(signers[2]).rejectAction(actionId);
+
+      expect(await lpStaking.pendingActionCount()).to.equal(0);
+      expect(await lpStaking.pendingChangeSignerActionId()).to.equal(0);
+
+      await expect(lpStaking.proposeSetHourlyRewardRate(NEW_RATE))
+        .to.emit(lpStaking, 'ActionProposed');
+    });
+
+    it('Should require expired actions to be marked expired before they stop blocking signer changes', async function () {
+      const oldSigner = signers[0];
+      const replacementSigner = signers[4];
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await ethers.provider.send('evm_increaseTime', [7 * 24 * 60 * 60 + 1]);
+      await ethers.provider.send('evm_mine', []);
+
+      await expect(
+        lpStaking.proposeChangeSigner(oldSigner.address, replacementSigner.address)
+      ).to.be.revertedWith('Pending action exists');
+
+      await lpStaking.handleExpiredAction(actionId);
+
+      expect(await lpStaking.pendingActionCount()).to.equal(0);
+
+      await expect(lpStaking.proposeChangeSigner(oldSigner.address, replacementSigner.address))
+        .to.emit(lpStaking, 'ActionProposed');
+    });
   });
 
   describe('Reward Obligation Tracking', function () {

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -733,6 +733,91 @@ describe('LPStaking', function () {
         const balance = await rewardToken.balanceOf(signers[1].address);
         expect(balance).to.equal(STAKE_AMOUNT);
     });
+
+    it('Should reject duplicate initial signers', async function () {
+      const LPStaking = await ethers.getContractFactory('LPStaking');
+
+      await expect(
+        LPStaking.deploy(await rewardToken.getAddress(), [
+          owner.address,
+          owner.address,
+          signers[0].address,
+          signers[1].address,
+        ])
+      ).to.be.revertedWith('Duplicate signer');
+    });
+
+    it('Should not let one signer permanently reject an action', async function () {
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await expect(lpStaking.connect(signers[2]).rejectAction(actionId))
+        .to.emit(lpStaking, 'ActionRejected')
+        .withArgs(actionId, signers[2].address);
+
+      const actionAfterOneRejection = await lpStaking.actions(actionId);
+      expect(actionAfterOneRejection.rejections).to.equal(1);
+      expect(actionAfterOneRejection.rejected).to.be.false;
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+      await lpStaking.connect(signers[1]).approveAction(actionId);
+
+      await expect(lpStaking.executeAction(actionId))
+        .to.emit(lpStaking, 'HourlyRateUpdated')
+        .withArgs(NEW_RATE);
+    });
+
+    it('Should only mark an action rejected after the rejection threshold', async function () {
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(signers[0]).rejectAction(actionId);
+      await lpStaking.connect(signers[1]).rejectAction(actionId);
+
+      let action = await lpStaking.actions(actionId);
+      expect(action.rejections).to.equal(2);
+      expect(action.rejected).to.be.false;
+
+      await lpStaking.connect(signers[2]).rejectAction(actionId);
+
+      action = await lpStaking.actions(actionId);
+      expect(action.rejections).to.equal(3);
+      expect(action.rejected).to.be.true;
+
+      await expect(lpStaking.connect(signers[0]).executeAction(actionId))
+        .to.be.revertedWith('Action was rejected');
+    });
+
+    it('Should prevent signers from approving after rejecting', async function () {
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(signers[0]).rejectAction(actionId);
+
+      await expect(lpStaking.connect(signers[0]).approveAction(actionId))
+        .to.be.revertedWith('Cannot approve after rejecting');
+    });
+
+    it('Should prevent signers from rejecting after approving', async function () {
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+
+      await expect(lpStaking.connect(signers[0]).rejectAction(actionId))
+        .to.be.revertedWith('Cannot reject after approving');
+    });
+
+    it('Should prevent direct ADMIN_ROLE renounce to keep signer state in sync', async function () {
+      const ADMIN_ROLE = await lpStaking.ADMIN_ROLE();
+
+      await expect(lpStaking.connect(owner).renounceRole(ADMIN_ROLE, owner.address))
+        .to.be.revertedWith('ADMIN_ROLE cannot be renounced');
+    });
   });
 
   describe('Reward Obligation Tracking', function () {

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -774,20 +774,23 @@ describe('LPStaking', function () {
       const actionId = (event as any)?.args?.actionId;
 
       await lpStaking.connect(signers[0]).rejectAction(actionId);
-      await lpStaking.connect(signers[1]).rejectAction(actionId);
 
       let action = await lpStaking.actions(actionId);
-      expect(action.rejections).to.equal(2);
+      expect(action.rejections).to.equal(1);
       expect(action.rejected).to.be.false;
 
-      await lpStaking.connect(signers[2]).rejectAction(actionId);
+      await lpStaking.connect(signers[1]).rejectAction(actionId);
 
       action = await lpStaking.actions(actionId);
-      expect(action.rejections).to.equal(3);
+      expect(action.rejections).to.equal(2);
       expect(action.rejected).to.be.true;
 
       await expect(lpStaking.connect(signers[0]).executeAction(actionId))
         .to.be.revertedWith('Action was rejected');
+    });
+
+    it('Should use a two-signer rejection threshold', async function () {
+      expect(await lpStaking.REQUIRED_REJECTIONS()).to.equal(2);
     });
 
     it('Should prevent signers from approving after rejecting', async function () {
@@ -842,6 +845,26 @@ describe('LPStaking', function () {
         .to.emit(lpStaking, 'ActionProposed');
     });
 
+    it('Should block normal proposals while any action is pending', async function () {
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      expect(await lpStaking.pendingActionCount()).to.equal(1);
+
+      await expect(lpStaking.proposeSetHourlyRewardRate(NEW_RATE + 1n))
+        .to.be.revertedWith('Pending action exists');
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+      await lpStaking.connect(signers[1]).approveAction(actionId);
+      await lpStaking.executeAction(actionId);
+
+      expect(await lpStaking.pendingActionCount()).to.equal(0);
+
+      await expect(lpStaking.proposeSetHourlyRewardRate(NEW_RATE + 1n))
+        .to.emit(lpStaking, 'ActionProposed');
+    });
+
     it('Should block normal actions and additional signer changes while a signer change is pending', async function () {
       const oldSigner = signers[0];
       const replacementSigner = signers[4];
@@ -855,7 +878,7 @@ describe('LPStaking', function () {
       expect(await lpStaking.pendingChangeSignerActionId()).to.equal(actionId);
 
       await expect(lpStaking.proposeSetHourlyRewardRate(NEW_RATE))
-        .to.be.revertedWith('Pending signer change exists');
+        .to.be.revertedWith('Pending action exists');
 
       await expect(
         lpStaking.proposeChangeSigner(signers[1].address, signers[5].address)
@@ -873,7 +896,6 @@ describe('LPStaking', function () {
 
       await lpStaking.connect(signers[0]).rejectAction(actionId);
       await lpStaking.connect(signers[1]).rejectAction(actionId);
-      await lpStaking.connect(signers[2]).rejectAction(actionId);
 
       expect(await lpStaking.pendingActionCount()).to.equal(0);
       expect(await lpStaking.pendingChangeSignerActionId()).to.equal(0);


### PR DESCRIPTION
## Summary

Hardens the LP staking contract governance flow so a single signer can no longer permanently veto multisig actions.

## Changes

- Adds a `REQUIRED_REJECTIONS` threshold matching the existing 3-of-4 approval threshold.
- Tracks per-action rejection count and rejecting signers.
- Keeps single rejections non-final until the rejection threshold is reached.
- Prevents approve-after-reject and reject-after-approve vote flipping.
- Rejects duplicate initial signer addresses in the constructor.
- Blocks direct `ADMIN_ROLE` renounce so the role state cannot silently desync from the `signers` array.
- Adds focused governance regression tests.

## Why

The previous `rejectAction` implementation let any one signer irreversibly kill any pending action, including a `CHANGE_SIGNER` proposal intended to remove that signer. That created an unrecoverable single-signer denial-of-service path inside governance.

## Validation

- `npx hardhat compile`
- `npx hardhat test --network hardhat`