### PR TITLE
Cap reward withdrawals by surplus

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -238,7 +238,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         return stakesArray;
     }
 
-    function getTotalRewardObligation() external view returns (uint256) {
+    function getTotalRewardObligation() public view returns (uint256) {
         uint256 pending = 0;
         for (uint i = 0; i < activePairs.length; i++) {
             address lpToken = activePairs[i];
@@ -258,6 +258,15 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             }
         }
         return totalRewardsObligated + pending;
+    }
+
+    function getAvailableRewardSurplus() public view returns (uint256) {
+        uint256 balance = rewardToken.balanceOf(address(this));
+        uint256 obligation = getTotalRewardObligation();
+        if (balance <= obligation) {
+            return 0;
+        }
+        return balance - obligation;
     }
 
     // ============ User Actions ============
@@ -339,8 +348,8 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(recipient != address(0), "Invalid recipient address");
         require(amount > 0, "Amount must be greater than zero");
         require(
-            amount <= rewardToken.balanceOf(address(this)),
-            "Amount exceeds contract balance"
+            amount <= getAvailableRewardSurplus(),
+            "Amount exceeds surplus rewards"
         );
         require(amount <= type(uint128).max, "Amount too large");
 
@@ -588,8 +597,8 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         } else if (pa.actionType == ActionType.WITHDRAW_REWARDS) {
             require(pa.recipient != address(0), "Invalid recipient");
             require(
-                rewardToken.balanceOf(address(this)) >= pa.withdrawAmount,
-                "Insufficient contract balance"
+                pa.withdrawAmount <= getAvailableRewardSurplus(),
+                "Amount exceeds surplus rewards"
             );
 
             rewardToken.safeTransfer(pa.recipient, pa.withdrawAmount);

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -816,5 +816,78 @@ describe('LPStaking', function () {
       const remainingObligation = await lpStaking.getTotalRewardObligation();
       expect(remainingObligation).to.be.closeTo(HOURLY_REWARD / 2n, HOURLY_REWARD / 1000n);
     });
+
+    it('Should report reward surplus after reserving obligations', async function () {
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const obligation = await lpStaking.getTotalRewardObligation();
+      const surplus = await lpStaking.getAvailableRewardSurplus();
+      const rewardBalance = await rewardToken.balanceOf(await lpStaking.getAddress());
+
+      expect(obligation).to.be.closeTo(HOURLY_REWARD, HOURLY_REWARD / 1000n);
+      expect(surplus).to.equal(rewardBalance - obligation);
+    });
+
+    it('Should reject reward withdrawals that exceed surplus at proposal time', async function () {
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const surplus = await lpStaking.getAvailableRewardSurplus();
+
+      await expect(
+        lpStaking.proposeWithdrawRewards(signers[1].address, surplus + 1n)
+      ).to.be.revertedWith('Amount exceeds surplus rewards');
+    });
+
+    it('Should reject reward withdrawals that exceed surplus at execution time', async function () {
+      const receipt = await (
+        await lpStaking.proposeWithdrawRewards(signers[1].address, REWARD_SUPPLY)
+      ).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+      await lpStaking.connect(signers[1]).approveAction(actionId);
+
+      await expect(lpStaking.executeAction(actionId))
+        .to.be.revertedWith('Amount exceeds surplus rewards');
+    });
+
+    it('Should preserve claim solvency after withdrawing only surplus rewards', async function () {
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const surplus = await lpStaking.getAvailableRewardSurplus();
+      const withdrawalBuffer = ethers.parseEther('1');
+      const withdrawAmount = surplus - withdrawalBuffer;
+
+      const receipt = await (
+        await lpStaking.proposeWithdrawRewards(signers[1].address, withdrawAmount)
+      ).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+      await lpStaking.connect(signers[1]).approveAction(actionId);
+      await lpStaking.executeAction(actionId);
+
+      const initialUserRewardBalance = await rewardToken.balanceOf(user1.address);
+      await lpStaking.connect(user1).claimRewards(lpTokenAddress);
+      const finalUserRewardBalance = await rewardToken.balanceOf(user1.address);
+
+      expect(finalUserRewardBalance).to.be.gt(initialUserRewardBalance);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Caps admin reward withdrawals by available surplus instead of raw reward-token balance, so withdrawals cannot spend rewards already owed to stakers.

## Changes

- Makes `getTotalRewardObligation()` public so the contract can reuse the live obligation calculation internally.
- Adds `getAvailableRewardSurplus()` for contract logic, admin tooling, and UI display.
- Checks surplus in `proposeWithdrawRewards()`.
- Re-checks surplus in `executeAction()` for `WITHDRAW_REWARDS`, because obligations can increase while a proposal is waiting for approvals.
- Adds regression tests for proposal-time rejection, execution-time rejection, surplus reporting, and claim solvency after a valid surplus withdrawal.

## Why

The previous withdrawal path only checked `rewardToken.balanceOf(address(this))`. Since the contract already tracks earned reward obligations, admins could withdraw tokens that users had already earned, causing later claims to revert with insufficient reward balance.

## UI / Operations Note

Withdrawals are intentionally checked again at execution time. A proposal that is safe when created can become unsafe before the final signature if users earn more rewards in the meantime.

The UI should recommend a buffer when creating withdrawal proposals. With the current reward rate of 3 LIB/hour, a simple estimate is:

```text
recommendedMaxWithdrawal = currentSurplus - ((expectedSigningDelayHours + safetyMarginHours) * 3 LIB)
```

For example, with a 24-hour expected signing delay and a 6-hour safety margin, reserve at least 90 LIB from the displayed surplus. The contract execution-time check remains the source of truth.

## Validation

- `npx hardhat compile`
- `npx hardhat test --network hardhat`