### PR TITLE
Add internal staking accounting

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -78,6 +78,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     // Reward tracking state
     mapping(address => uint256) public rewardPerTokenStored;
     mapping(address => uint256) public lastUpdateTime;
+    mapping(address => uint256) public totalStaked;
     uint256 public totalWeight;
     uint256 public actionCounter;
     uint256 public totalRewardsObligated;
@@ -151,7 +152,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
 
         if (
             block.timestamp > lastUpdateTime[lpToken] &&
-            IERC20(lpToken).balanceOf(address(this)) > 0 &&
+            totalStaked[lpToken] > 0 &&
             totalWeight > 0
         ) {
             uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
@@ -161,7 +162,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
                 pairs[lpToken].weight) / totalWeight;
             currentRewardPerToken +=
                 (pairRewards * PRECISION) /
-                IERC20(lpToken).balanceOf(address(this));
+                totalStaked[lpToken];
         }
 
         return
@@ -244,7 +245,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             address lpToken = activePairs[i];
             if (
                 pairs[lpToken].isActive &&
-                IERC20(lpToken).balanceOf(address(this)) > 0 &&
+                totalStaked[lpToken] > 0 &&
                 totalWeight > 0
             ) {
                 uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
@@ -275,12 +276,18 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             userStake.pendingRewards = earned(msg.sender, lpToken);
         }
 
-        userStake.amount += amount;
+        uint256 balanceBefore = IERC20(lpToken).balanceOf(address(this));
+        IERC20(lpToken).safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = IERC20(lpToken).balanceOf(address(this)) - balanceBefore;
+        require(received >= MIN_STAKE, "Received amount too low");
+        require(received <= type(uint128).max, "Stake amount too high");
+
+        userStake.amount += received;
+        totalStaked[lpToken] += received;
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
         userStake.lastRewardTime = uint64(block.timestamp);
 
-        IERC20(lpToken).safeTransferFrom(msg.sender, address(this), amount);
-        emit StakeAdded(msg.sender, lpToken, amount);
+        emit StakeAdded(msg.sender, lpToken, received);
     }
 
     function unstake(
@@ -564,7 +571,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             pairs[lpToken].weight = 0;
 
             // Only fully remove the pair if TVL is zero
-            if (IERC20(lpToken).balanceOf(address(this)) == 0) {
+            if (totalStaked[lpToken] == 0) {
                 pairs[lpToken].isActive = false;
                 pairs[lpToken].lpToken = IERC20(address(0));
                 _removeActivePair(lpToken);
@@ -644,6 +651,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         } else {
             userStake.amount -= amount;
         }
+        totalStaked[lpToken] -= amount;
 
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
         if (shouldClaimRewards && rewards > 0) {
@@ -696,7 +704,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     }
 
     function updateRewardPerToken(address lpToken) internal {
-        uint256 totalSupply = IERC20(lpToken).balanceOf(address(this));
+        uint256 totalSupply = totalStaked[lpToken];
         uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
 
         if (totalSupply > 0 && timeDelta > 0 && totalWeight > 0) {

--- a/contracts/test/MockFeeOnTransferERC20.sol
+++ b/contracts/test/MockFeeOnTransferERC20.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferERC20 is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint256 _feeBps
+    ) ERC20(name, symbol) {
+        require(_feeBps <= 10_000, "Invalid fee");
+        feeBps = _feeBps;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 fee = (value * feeBps) / 10_000;
+        uint256 net = value - fee;
+
+        super._update(from, to, net);
+        if (fee > 0) {
+            super._update(from, address(0), fee);
+        }
+    }
+}

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -204,6 +204,7 @@ describe('LPStaking', function () {
 
       const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
       expect(userStake.amount).to.equal(STAKE_AMOUNT);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(STAKE_AMOUNT);
     });
 
     it('Should not allow staking below minimum', async function () {
@@ -236,6 +237,29 @@ describe('LPStaking', function () {
       
       const finalContractBalance = await lpToken.balanceOf(contractAddress);
       expect(finalContractBalance - initialContractBalance).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should credit only the received amount for fee-on-transfer LP tokens', async function () {
+      const feeToken = await ethers.deployContract('MockFeeOnTransferERC20', [
+        'Fee LP Token',
+        'FLP',
+        100,
+      ]);
+      const feeTokenAddress = await feeToken.getAddress();
+      const expectedReceived = (STAKE_AMOUNT * 99n) / 100n;
+
+      await feeToken.mint(user1.address, INITIAL_BALANCE);
+      await feeToken.connect(user1).approve(await lpStaking.getAddress(), INITIAL_BALANCE);
+      await setupPairOnly(lpStaking, feeTokenAddress, signers);
+
+      await expect(lpStaking.connect(user1).stake(feeTokenAddress, STAKE_AMOUNT))
+        .to.emit(lpStaking, 'StakeAdded')
+        .withArgs(user1.address, feeTokenAddress, expectedReceived);
+
+      const userStake = await lpStaking.getUserStakeInfo(user1.address, feeTokenAddress);
+      expect(userStake.amount).to.equal(expectedReceived);
+      expect(await lpStaking.totalStaked(feeTokenAddress)).to.equal(expectedReceived);
+      expect(await feeToken.balanceOf(await lpStaking.getAddress())).to.equal(expectedReceived);
     });
 
     it('Should update lastRewardTime on stake', async function () {
@@ -290,6 +314,7 @@ describe('LPStaking', function () {
       const finalBalance = await lpToken.balanceOf(user1.address);
       
       expect(finalBalance - initialBalance).to.equal(STAKE_AMOUNT);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(0);
     });
 
     it('Should allow partial unstaking LP tokens to a different receiver', async function () {
@@ -314,6 +339,7 @@ describe('LPStaking', function () {
 
       const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
       expect(userStake.amount).to.equal(STAKE_AMOUNT - partialAmount);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(STAKE_AMOUNT - partialAmount);
       expect(await lpToken.balanceOf(user1.address)).to.equal(initialUserBalance);
       expect(await lpToken.balanceOf(receiver.address)).to.equal(initialReceiverBalance + partialAmount);
     });
@@ -583,6 +609,40 @@ describe('LPStaking', function () {
       const rewardsEarned = finalBalance - initialBalance;
       const tolerance = HOURLY_REWARD / 1000n; // 0.1% tolerance
       expect(rewardsEarned).to.be.closeTo(HOURLY_REWARD, tolerance);
+    });
+
+    it('Should not dilute rewards from direct LP token transfers', async function () {
+      const directSender = signers[0];
+      await lpToken.mint(directSender.address, STAKE_AMOUNT);
+
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+      await lpToken.connect(directSender).transfer(await lpStaking.getAddress(), STAKE_AMOUNT);
+
+      expect(await lpToken.balanceOf(await lpStaking.getAddress())).to.equal(STAKE_AMOUNT * 2n);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialBalance = await rewardToken.balanceOf(user1.address);
+      await lpStaking.connect(user1).claimRewards(lpTokenAddress);
+      const finalBalance = await rewardToken.balanceOf(user1.address);
+
+      expect(finalBalance - initialBalance).to.be.closeTo(HOURLY_REWARD, HOURLY_REWARD / 1000n);
+    });
+
+    it('Should not accrue phantom obligations from direct LP token transfers without stake', async function () {
+      const directSender = signers[0];
+      await lpToken.mint(directSender.address, STAKE_AMOUNT);
+      await lpToken.connect(directSender).transfer(await lpStaking.getAddress(), STAKE_AMOUNT);
+
+      expect(await lpToken.balanceOf(await lpStaking.getAddress())).to.equal(STAKE_AMOUNT);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(0);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      expect(await lpStaking.getTotalRewardObligation()).to.equal(0);
     });
 
     it('Should allow claiming small rewards', async function () {


### PR DESCRIPTION
## Summary

Adds internal per-pair stake accounting and uses it as the reward denominator instead of raw LP token balance.

## Changes

- Adds `totalStaked[lpToken]` tracking.
- Updates `stake()` and `_unstake()` to maintain internal totals.
- Uses `totalStaked` in `earned()`, `updateRewardPerToken()`, and `getTotalRewardObligation()`.
- Uses `totalStaked` for pair-removal zero-TVL checks.
- Changes `stake()` to credit the actual received token amount via balance delta.
- Adds a fee-on-transfer mock token for regression coverage.
- Adds tests for direct LP transfer dilution, phantom obligations, fee-on-transfer staking, and total-staked updates on stake/unstake.

## Why

The previous reward accounting used `IERC20(lpToken).balanceOf(address(this))` as the total-staked denominator. Anyone could transfer LP tokens directly to the contract, diluting real stakers and creating phantom reward accounting. Internal accounting makes rewards depend only on stake that entered through `stake()`.

## Stacked PR Note

The pair lifecycle PR should branch from this PR. In particular, lifecycle finalization should use `totalStaked[lpToken]` instead of raw LP token balance when deciding whether a pair has no remaining stake.

## Validation

- `npx hardhat compile`
- `npx hardhat test --network hardhat`