### PR TITLE
Fix pair lifecycle cleanup

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -604,6 +604,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             });
             activePairs.push(pa.pairToAdd);
             totalWeight += pa.weightToAdd;
+            rewardPerTokenStored[pa.pairToAdd] = 0;
             lastUpdateTime[pa.pairToAdd] = block.timestamp;
             emit PairAdded(pa.pairToAdd, pa.platformToAdd, pa.weightToAdd);
         } else if (pa.actionType == ActionType.REMOVE_PAIR) {
@@ -613,12 +614,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             totalWeight -= pairs[lpToken].weight;
             pairs[lpToken].weight = 0;
 
-            // Only fully remove the pair if TVL is zero
-            if (totalStaked[lpToken] == 0) {
-                pairs[lpToken].isActive = false;
-                pairs[lpToken].lpToken = IERC20(address(0));
-                _removeActivePair(lpToken);
-            }
+            _finalizePairRemovalIfEmpty(lpToken);
 
             emit PairRemoved(lpToken, pa.pairNameToAdd);
         } else if (pa.actionType == ActionType.CHANGE_SIGNER) {
@@ -716,6 +712,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         }
 
         IERC20(lpToken).safeTransfer(receiver, amount);
+        _finalizePairRemovalIfEmpty(lpToken);
 
         emit StakeRemoved(msg.sender, lpToken, amount);
         emit StakeRemovedTo(msg.sender, receiver, lpToken, amount);
@@ -732,13 +729,21 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(receiver != address(0), "Invalid receiver");
 
         LiquidityPair storage pair = pairs[lpToken];
-        require(pair.isActive, "Pair not active");
+        UserStake storage userStake = userStakes[msg.sender][lpToken];
+        require(
+            pair.isActive || userStake.pendingRewards > 0,
+            "Pair not active"
+        );
 
-        updateRewardPerToken(lpToken);
-        uint256 rewards = earned(msg.sender, lpToken);
+        uint256 rewards;
+        if (pair.isActive) {
+            updateRewardPerToken(lpToken);
+            rewards = earned(msg.sender, lpToken);
+        } else {
+            rewards = userStake.pendingRewards;
+        }
         require(rewards > 0, "No rewards to claim");
 
-        UserStake storage userStake = userStakes[msg.sender][lpToken];
         userStake.pendingRewards = 0;
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
 
@@ -755,6 +760,15 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             if (pairs[lpToken].isActive) {
                 updateRewardPerToken(lpToken);
             }
+        }
+    }
+
+    function _finalizePairRemovalIfEmpty(address lpToken) internal {
+        LiquidityPair storage pair = pairs[lpToken];
+        if (pair.isActive && pair.weight == 0 && totalStaked[lpToken] == 0) {
+            pair.isActive = false;
+            pair.lpToken = IERC20(address(0));
+            _removeActivePair(lpToken);
         }
     }
 

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -72,6 +72,13 @@ describe('LPStaking', function () {
     return actionId;
   }
 
+  async function approveAndExecuteAction(lpStaking: LPStaking, actionId: bigint, signers: SignerWithAddress[]) {
+    for (let i = 0; i < 2; i++) {
+      await lpStaking.connect(signers[i]).approveAction(actionId);
+    }
+    await lpStaking.executeAction(actionId);
+  }
+
   async function deployUnderfundedStakedFixture() {
     const { lpStaking, lpToken, signers } = await deployBaseFixture();
     const lpTokenAddress = await lpToken.getAddress();
@@ -578,6 +585,51 @@ describe('LPStaking', function () {
       const finalUserBalance = await rewardToken.balanceOf(user1.address);
       expect(finalUserBalance - initialUserBalance).to.equal(userStakeStruct.pendingRewards);
     });
+
+    it('Should allow claiming pending rewards after a pair is fully removed', async function () {
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      await lpStaking.connect(user1).unstake(lpTokenAddress, STAKE_AMOUNT, false);
+      const pendingRewards = (await lpStaking.userStakes(user1.address, lpTokenAddress)).pendingRewards;
+      expect(pendingRewards).to.be.gt(0);
+
+      const receipt = await (await lpStaking.proposeRemovePair(lpTokenAddress)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      const pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.false;
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialRewardBalance = await rewardToken.balanceOf(user1.address);
+      await expect(lpStaking.connect(user1).claimRewards(lpTokenAddress))
+        .to.emit(lpStaking, 'RewardsClaimed')
+        .withArgs(user1.address, lpTokenAddress, pendingRewards);
+
+      expect(await rewardToken.balanceOf(user1.address)).to.equal(initialRewardBalance + pendingRewards);
+    });
+
+    it('Should finalize a removed pair after the last stake exits', async function () {
+      const receipt = await (await lpStaking.proposeRemovePair(lpTokenAddress)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      let pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.true;
+      expect(pair.weight).to.equal(0);
+
+      await lpStaking.connect(user1).unstake(lpTokenAddress, STAKE_AMOUNT, false);
+
+      pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.false;
+      expect(pair.token).to.equal(ethers.ZeroAddress);
+      expect(await lpStaking.getActivePairs()).to.not.include(lpTokenAddress);
+    });
   });
 
   describe('Rewards', function () {
@@ -671,6 +723,38 @@ describe('LPStaking', function () {
       
       // Check that the event was emitted (without checking exact amount)
       expect(tx).to.emit(lpStaking, 'RewardsClaimed').withArgs(freshUser.address, lpTokenAddress);
+    });
+
+    it('Should reset reward accumulators when a fully removed pair is re-added', async function () {
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      await lpStaking.connect(user1).unstake(lpTokenAddress, STAKE_AMOUNT, false);
+      expect(await lpStaking.rewardPerTokenStored(lpTokenAddress)).to.be.gt(0);
+
+      let receipt = await (await lpStaking.proposeRemovePair(lpTokenAddress)).wait();
+      let event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      let actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      let pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.false;
+
+      receipt = await (
+        await lpStaking.proposeAddPair(lpTokenAddress, 'LIB-USDT', 'Uniswap-V2', ethers.parseEther('7'))
+      ).wait();
+      event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.true;
+      expect(await lpStaking.rewardPerTokenStored(lpTokenAddress)).to.equal(0);
+
+      const latestBlock = await ethers.provider.getBlock('latest');
+      expect(await lpStaking.lastUpdateTime(lpTokenAddress)).to.equal(latestBlock?.timestamp);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes pair lifecycle edge cases on top of the internal staking accounting PR.

## Changes

- Allows users to claim already-pending rewards after a pair has been fully removed.
- Avoids accruing new rewards for inactive pairs; inactive-pair claims only pay stored `pendingRewards`.
- Adds `_finalizePairRemovalIfEmpty()` using `totalStaked[lpToken]` to finalize zero-stake removed pairs.
- Calls the finalizer during `REMOVE_PAIR` execution and after unstake exits.
- Explicitly resets `rewardPerTokenStored[lpToken]` when a previously removed pair is re-added.
- Adds regression tests for pending claims after removal, automatic finalization after last unstake, and clean re-add accounting.

## Why

A user could fully unstake with `shouldClaimRewards = false`, leaving rewards in `pendingRewards`. If admins then fully removed the pair, the old `_claimRewards()` path reverted because the pair was inactive, trapping earned rewards. Removed zero-weight pairs could also remain active after all stake exited until admins removed them again.

## Stacked PR Note

This PR intentionally targets `codex/internal-staking-accounting` instead of `main`, because pair finalization should depend on `totalStaked[lpToken]` rather than raw LP token balance. Merge order should be:

1. #16 internal staking accounting
2. this PR

## Validation

- `npx hardhat compile`
- `npx hardhat test --network hardhat`