### PR TITLE
Add cleanup guards

### DIFF
--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -78,6 +78,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     // Reward tracking state
     mapping(address => uint256) public rewardPerTokenStored;
     mapping(address => uint256) public lastUpdateTime;
+    mapping(address => uint256) public totalStaked;
     uint256 public totalWeight;
     uint256 public actionCounter;
     uint256 public totalRewardsObligated;
@@ -151,7 +152,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
 
         if (
             block.timestamp > lastUpdateTime[lpToken] &&
-            IERC20(lpToken).balanceOf(address(this)) > 0 &&
+            totalStaked[lpToken] > 0 &&
             totalWeight > 0
         ) {
             uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
@@ -161,7 +162,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
                 pairs[lpToken].weight) / totalWeight;
             currentRewardPerToken +=
                 (pairRewards * PRECISION) /
-                IERC20(lpToken).balanceOf(address(this));
+                totalStaked[lpToken];
         }
 
         return
@@ -244,7 +245,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             address lpToken = activePairs[i];
             if (
                 pairs[lpToken].isActive &&
-                IERC20(lpToken).balanceOf(address(this)) > 0 &&
+                totalStaked[lpToken] > 0 &&
                 totalWeight > 0
             ) {
                 uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
@@ -275,12 +276,18 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             userStake.pendingRewards = earned(msg.sender, lpToken);
         }
 
-        userStake.amount += amount;
+        uint256 balanceBefore = IERC20(lpToken).balanceOf(address(this));
+        IERC20(lpToken).safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = IERC20(lpToken).balanceOf(address(this)) - balanceBefore;
+        require(received >= MIN_STAKE, "Received amount too low");
+        require(received <= type(uint128).max, "Stake amount too high");
+
+        userStake.amount += received;
+        totalStaked[lpToken] += received;
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
         userStake.lastRewardTime = uint64(block.timestamp);
 
-        IERC20(lpToken).safeTransferFrom(msg.sender, address(this), amount);
-        emit StakeAdded(msg.sender, lpToken, amount);
+        emit StakeAdded(msg.sender, lpToken, received);
     }
 
     function unstake(
@@ -564,7 +571,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             pairs[lpToken].weight = 0;
 
             // Only fully remove the pair if TVL is zero
-            if (IERC20(lpToken).balanceOf(address(this)) == 0) {
+            if (totalStaked[lpToken] == 0) {
                 pairs[lpToken].isActive = false;
                 pairs[lpToken].lpToken = IERC20(address(0));
                 _removeActivePair(lpToken);
@@ -644,6 +651,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         } else {
             userStake.amount -= amount;
         }
+        totalStaked[lpToken] -= amount;
 
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
         if (shouldClaimRewards && rewards > 0) {
@@ -696,7 +704,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     }
 
     function updateRewardPerToken(address lpToken) internal {
-        uint256 totalSupply = IERC20(lpToken).balanceOf(address(this));
+        uint256 totalSupply = totalStaked[lpToken];
         uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
 
         if (totalSupply > 0 && timeDelta > 0 && totalWeight > 0) {

--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -508,7 +508,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         _approveActionInternal(actionId);
     }
 
-    function executeAction(uint256 actionId) external onlyRole(ADMIN_ROLE) {
+    function executeAction(uint256 actionId) external nonReentrant onlyRole(ADMIN_ROLE) {
         require(actionId > 0 && actionId <= actionCounter, "Invalid actionId");
         PendingAction storage pa = actions[actionId];
         require(!pa.executed, "Already executed");
@@ -519,6 +519,8 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             block.timestamp <= pa.proposedTime + ACTION_EXPIRY,
             "Action has expired"
         );
+
+        pa.executed = true;
 
         if (
             pa.actionType == ActionType.ADD_PAIR ||
@@ -609,7 +611,6 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             emit RewardsWithdrawn(pa.recipient, pa.withdrawAmount);
         }
 
-        pa.executed = true;
         emit ActionExecuted(actionId);
     }
 

--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
     using SafeERC20 for IERC20;
@@ -156,10 +157,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             totalWeight > 0
         ) {
             uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
-            uint256 rewardPerSecond = hourlyRewardRate / SECONDS_PER_HOUR;
-            uint256 pairRewards = (rewardPerSecond *
-                timeDelta *
-                pairs[lpToken].weight) / totalWeight;
+            uint256 pairRewards = _calculatePairRewards(lpToken, timeDelta);
             currentRewardPerToken +=
                 (pairRewards * PRECISION) /
                 totalStaked[lpToken];
@@ -250,10 +248,10 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             ) {
                 uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
                 if (timeDelta > 0) {
-                    uint256 rewardPerSecond = hourlyRewardRate / SECONDS_PER_HOUR;
-                    uint256 pairRewards = (rewardPerSecond *
-                        timeDelta *
-                        pairs[lpToken].weight) / totalWeight;
+                    uint256 pairRewards = _calculatePairRewards(
+                        lpToken,
+                        timeDelta
+                    );
                     pending += pairRewards;
                 }
             }
@@ -329,8 +327,15 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         emit ActionExpired(actionId);
     }
 
-    function cleanupExpiredActions() external onlyRole(ADMIN_ROLE) {
-        for (uint256 i = 1; i <= actionCounter; i++) {
+    function cleanupExpiredActions(
+        uint256 start,
+        uint256 end
+    ) external onlyRole(ADMIN_ROLE) {
+        require(start > 0, "Invalid start");
+        require(end >= start, "Invalid range");
+        require(end <= actionCounter, "Invalid end");
+
+        for (uint256 i = start; i <= end; i++) {
             PendingAction storage pa = actions[i];
             if (!pa.executed && !pa.expired && isActionExpired(i)) {
                 pa.expired = true;
@@ -423,6 +428,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         uint256 weight
     ) external onlyRole(ADMIN_ROLE) returns (uint256) {
         require(lpToken != address(0), "Invalid pair");
+        require(lpToken != address(rewardToken), "Reward token cannot be pair");
         require(weight > 0, "Weight must be greater than 0");
         require(weight <= MAX_WEIGHT, "Weight exceeds maximum");
         require(bytes(pairName).length > 0, "Empty pair name");
@@ -544,6 +550,10 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             require(
                 pairs[pa.pairToAdd].lpToken == IERC20(address(0)),
                 "Pair already exists"
+            );
+            require(
+                pa.pairToAdd != address(rewardToken),
+                "Reward token cannot be pair"
             );
             require(activePairs.length < MAX_PAIRS, "Too many pairs");
             require(pa.weightToAdd <= MAX_WEIGHT, "Weight too high");
@@ -722,10 +732,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         uint256 timeDelta = block.timestamp - lastUpdateTime[lpToken];
 
         if (totalSupply > 0 && timeDelta > 0 && totalWeight > 0) {
-            uint256 rewardPerSecond = hourlyRewardRate / SECONDS_PER_HOUR;
-            uint256 pairRewards = (rewardPerSecond *
-                timeDelta *
-                pairs[lpToken].weight) / totalWeight;
+            uint256 pairRewards = _calculatePairRewards(lpToken, timeDelta);
             rewardPerTokenStored[lpToken] +=
                 (pairRewards * PRECISION) /
                 totalSupply;
@@ -735,12 +742,16 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         lastUpdateTime[lpToken] = block.timestamp;
     }
 
-    function updateRewards(address user, address lpToken) internal {
-        updateRewardPerToken(lpToken);
-        UserStake storage userStake = userStakes[user][lpToken];
-        userStake.pendingRewards = earned(user, lpToken);
-        userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
-        userStake.lastRewardTime = uint64(block.timestamp);
+    function _calculatePairRewards(
+        address lpToken,
+        uint256 timeDelta
+    ) internal view returns (uint256) {
+        uint256 elapsedRewards = Math.mulDiv(
+            hourlyRewardRate,
+            timeDelta,
+            SECONDS_PER_HOUR
+        );
+        return Math.mulDiv(elapsedRewards, pairs[lpToken].weight, totalWeight);
     }
 
     function _approveActionInternal(uint256 actionId) internal {

--- a/contracts/LPStaking.sol
+++ b/contracts/LPStaking.sol
@@ -561,6 +561,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             });
             activePairs.push(pa.pairToAdd);
             totalWeight += pa.weightToAdd;
+            rewardPerTokenStored[pa.pairToAdd] = 0;
             lastUpdateTime[pa.pairToAdd] = block.timestamp;
             emit PairAdded(pa.pairToAdd, pa.platformToAdd, pa.weightToAdd);
         } else if (pa.actionType == ActionType.REMOVE_PAIR) {
@@ -570,12 +571,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             totalWeight -= pairs[lpToken].weight;
             pairs[lpToken].weight = 0;
 
-            // Only fully remove the pair if TVL is zero
-            if (totalStaked[lpToken] == 0) {
-                pairs[lpToken].isActive = false;
-                pairs[lpToken].lpToken = IERC20(address(0));
-                _removeActivePair(lpToken);
-            }
+            _finalizePairRemovalIfEmpty(lpToken);
 
             emit PairRemoved(lpToken, pa.pairNameToAdd);
         } else if (pa.actionType == ActionType.CHANGE_SIGNER) {
@@ -661,6 +657,7 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         }
 
         IERC20(lpToken).safeTransfer(receiver, amount);
+        _finalizePairRemovalIfEmpty(lpToken);
 
         emit StakeRemoved(msg.sender, lpToken, amount);
         emit StakeRemovedTo(msg.sender, receiver, lpToken, amount);
@@ -677,13 +674,21 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
         require(receiver != address(0), "Invalid receiver");
 
         LiquidityPair storage pair = pairs[lpToken];
-        require(pair.isActive, "Pair not active");
+        UserStake storage userStake = userStakes[msg.sender][lpToken];
+        require(
+            pair.isActive || userStake.pendingRewards > 0,
+            "Pair not active"
+        );
 
-        updateRewardPerToken(lpToken);
-        uint256 rewards = earned(msg.sender, lpToken);
+        uint256 rewards;
+        if (pair.isActive) {
+            updateRewardPerToken(lpToken);
+            rewards = earned(msg.sender, lpToken);
+        } else {
+            rewards = userStake.pendingRewards;
+        }
         require(rewards > 0, "No rewards to claim");
 
-        UserStake storage userStake = userStakes[msg.sender][lpToken];
         userStake.pendingRewards = 0;
         userStake.rewardPerTokenPaid = rewardPerTokenStored[lpToken];
 
@@ -700,6 +705,15 @@ contract LPStaking is ReentrancyGuard, AccessControl, Ownable2Step {
             if (pairs[lpToken].isActive) {
                 updateRewardPerToken(lpToken);
             }
+        }
+    }
+
+    function _finalizePairRemovalIfEmpty(address lpToken) internal {
+        LiquidityPair storage pair = pairs[lpToken];
+        if (pair.isActive && pair.weight == 0 && totalStaked[lpToken] == 0) {
+            pair.isActive = false;
+            pair.lpToken = IERC20(address(0));
+            _removeActivePair(lpToken);
         }
     }
 

--- a/contracts/test/MockFeeOnTransferERC20.sol
+++ b/contracts/test/MockFeeOnTransferERC20.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferERC20 is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint256 _feeBps
+    ) ERC20(name, symbol) {
+        require(_feeBps <= 10_000, "Invalid fee");
+        feeBps = _feeBps;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 fee = (value * feeBps) / 10_000;
+        uint256 net = value - fee;
+
+        super._update(from, to, net);
+        if (fee > 0) {
+            super._update(from, address(0), fee);
+        }
+    }
+}

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -72,6 +72,13 @@ describe('LPStaking', function () {
     return actionId;
   }
 
+  async function approveAndExecuteAction(lpStaking: LPStaking, actionId: bigint, signers: SignerWithAddress[]) {
+    for (let i = 0; i < 2; i++) {
+      await lpStaking.connect(signers[i]).approveAction(actionId);
+    }
+    await lpStaking.executeAction(actionId);
+  }
+
   async function deployUnderfundedStakedFixture() {
     const { lpStaking, lpToken, signers } = await deployBaseFixture();
     const lpTokenAddress = await lpToken.getAddress();
@@ -578,6 +585,51 @@ describe('LPStaking', function () {
       const finalUserBalance = await rewardToken.balanceOf(user1.address);
       expect(finalUserBalance - initialUserBalance).to.equal(userStakeStruct.pendingRewards);
     });
+
+    it('Should allow claiming pending rewards after a pair is fully removed', async function () {
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      await lpStaking.connect(user1).unstake(lpTokenAddress, STAKE_AMOUNT, false);
+      const pendingRewards = (await lpStaking.userStakes(user1.address, lpTokenAddress)).pendingRewards;
+      expect(pendingRewards).to.be.gt(0);
+
+      const receipt = await (await lpStaking.proposeRemovePair(lpTokenAddress)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      const pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.false;
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialRewardBalance = await rewardToken.balanceOf(user1.address);
+      await expect(lpStaking.connect(user1).claimRewards(lpTokenAddress))
+        .to.emit(lpStaking, 'RewardsClaimed')
+        .withArgs(user1.address, lpTokenAddress, pendingRewards);
+
+      expect(await rewardToken.balanceOf(user1.address)).to.equal(initialRewardBalance + pendingRewards);
+    });
+
+    it('Should finalize a removed pair after the last stake exits', async function () {
+      const receipt = await (await lpStaking.proposeRemovePair(lpTokenAddress)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      let pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.true;
+      expect(pair.weight).to.equal(0);
+
+      await lpStaking.connect(user1).unstake(lpTokenAddress, STAKE_AMOUNT, false);
+
+      pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.false;
+      expect(pair.token).to.equal(ethers.ZeroAddress);
+      expect(await lpStaking.getActivePairs()).to.not.include(lpTokenAddress);
+    });
   });
 
   describe('Rewards', function () {
@@ -671,6 +723,38 @@ describe('LPStaking', function () {
       
       // Check that the event was emitted (without checking exact amount)
       expect(tx).to.emit(lpStaking, 'RewardsClaimed').withArgs(freshUser.address, lpTokenAddress);
+    });
+
+    it('Should reset reward accumulators when a fully removed pair is re-added', async function () {
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      await lpStaking.connect(user1).unstake(lpTokenAddress, STAKE_AMOUNT, false);
+      expect(await lpStaking.rewardPerTokenStored(lpTokenAddress)).to.be.gt(0);
+
+      let receipt = await (await lpStaking.proposeRemovePair(lpTokenAddress)).wait();
+      let event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      let actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      let pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.false;
+
+      receipt = await (
+        await lpStaking.proposeAddPair(lpTokenAddress, 'LIB-USDT', 'Uniswap-V2', ethers.parseEther('7'))
+      ).wait();
+      event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      actionId = (event as any)?.args?.actionId;
+      await approveAndExecuteAction(lpStaking, actionId, signers);
+
+      pair = await lpStaking.getPairInfo(lpTokenAddress);
+      expect(pair.isActive).to.be.true;
+      expect(await lpStaking.rewardPerTokenStored(lpTokenAddress)).to.equal(0);
+
+      const latestBlock = await ethers.provider.getBlock('latest');
+      expect(await lpStaking.lastUpdateTime(lpTokenAddress)).to.equal(latestBlock?.timestamp);
     });
   });
 

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -204,6 +204,7 @@ describe('LPStaking', function () {
 
       const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
       expect(userStake.amount).to.equal(STAKE_AMOUNT);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(STAKE_AMOUNT);
     });
 
     it('Should not allow staking below minimum', async function () {
@@ -236,6 +237,29 @@ describe('LPStaking', function () {
       
       const finalContractBalance = await lpToken.balanceOf(contractAddress);
       expect(finalContractBalance - initialContractBalance).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should credit only the received amount for fee-on-transfer LP tokens', async function () {
+      const feeToken = await ethers.deployContract('MockFeeOnTransferERC20', [
+        'Fee LP Token',
+        'FLP',
+        100,
+      ]);
+      const feeTokenAddress = await feeToken.getAddress();
+      const expectedReceived = (STAKE_AMOUNT * 99n) / 100n;
+
+      await feeToken.mint(user1.address, INITIAL_BALANCE);
+      await feeToken.connect(user1).approve(await lpStaking.getAddress(), INITIAL_BALANCE);
+      await setupPairOnly(lpStaking, feeTokenAddress, signers);
+
+      await expect(lpStaking.connect(user1).stake(feeTokenAddress, STAKE_AMOUNT))
+        .to.emit(lpStaking, 'StakeAdded')
+        .withArgs(user1.address, feeTokenAddress, expectedReceived);
+
+      const userStake = await lpStaking.getUserStakeInfo(user1.address, feeTokenAddress);
+      expect(userStake.amount).to.equal(expectedReceived);
+      expect(await lpStaking.totalStaked(feeTokenAddress)).to.equal(expectedReceived);
+      expect(await feeToken.balanceOf(await lpStaking.getAddress())).to.equal(expectedReceived);
     });
 
     it('Should update lastRewardTime on stake', async function () {
@@ -290,6 +314,7 @@ describe('LPStaking', function () {
       const finalBalance = await lpToken.balanceOf(user1.address);
       
       expect(finalBalance - initialBalance).to.equal(STAKE_AMOUNT);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(0);
     });
 
     it('Should allow partial unstaking LP tokens to a different receiver', async function () {
@@ -314,6 +339,7 @@ describe('LPStaking', function () {
 
       const userStake = await lpStaking.getUserStakeInfo(user1.address, lpTokenAddress);
       expect(userStake.amount).to.equal(STAKE_AMOUNT - partialAmount);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(STAKE_AMOUNT - partialAmount);
       expect(await lpToken.balanceOf(user1.address)).to.equal(initialUserBalance);
       expect(await lpToken.balanceOf(receiver.address)).to.equal(initialReceiverBalance + partialAmount);
     });
@@ -583,6 +609,40 @@ describe('LPStaking', function () {
       const rewardsEarned = finalBalance - initialBalance;
       const tolerance = HOURLY_REWARD / 1000n; // 0.1% tolerance
       expect(rewardsEarned).to.be.closeTo(HOURLY_REWARD, tolerance);
+    });
+
+    it('Should not dilute rewards from direct LP token transfers', async function () {
+      const directSender = signers[0];
+      await lpToken.mint(directSender.address, STAKE_AMOUNT);
+
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+      await lpToken.connect(directSender).transfer(await lpStaking.getAddress(), STAKE_AMOUNT);
+
+      expect(await lpToken.balanceOf(await lpStaking.getAddress())).to.equal(STAKE_AMOUNT * 2n);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialBalance = await rewardToken.balanceOf(user1.address);
+      await lpStaking.connect(user1).claimRewards(lpTokenAddress);
+      const finalBalance = await rewardToken.balanceOf(user1.address);
+
+      expect(finalBalance - initialBalance).to.be.closeTo(HOURLY_REWARD, HOURLY_REWARD / 1000n);
+    });
+
+    it('Should not accrue phantom obligations from direct LP token transfers without stake', async function () {
+      const directSender = signers[0];
+      await lpToken.mint(directSender.address, STAKE_AMOUNT);
+      await lpToken.connect(directSender).transfer(await lpStaking.getAddress(), STAKE_AMOUNT);
+
+      expect(await lpToken.balanceOf(await lpStaking.getAddress())).to.equal(STAKE_AMOUNT);
+      expect(await lpStaking.totalStaked(lpTokenAddress)).to.equal(0);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      expect(await lpStaking.getTotalRewardObligation()).to.equal(0);
     });
 
     it('Should allow claiming small rewards', async function () {

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -911,6 +911,9 @@ describe('LPStaking', function () {
 
         const balance = await rewardToken.balanceOf(signers[1].address);
         expect(balance).to.equal(STAKE_AMOUNT);
+
+        const action = await lpStaking.actions(actionId);
+        expect(action.executed).to.be.true;
     });
 
     it('Should clean up expired actions by bounded range', async function () {

--- a/test/LPStaking.test.ts
+++ b/test/LPStaking.test.ts
@@ -188,6 +188,17 @@ describe('LPStaking', function () {
       expect(pair.isActive).to.be.true;
       expect(pair.weight).to.equal(weight);
     });
+
+    it('Should reject adding the reward token as a liquidity pair', async function () {
+      await expect(
+        lpStaking.proposeAddPair(
+          await rewardToken.getAddress(),
+          'LIB',
+          'Uniswap-V2',
+          ethers.parseEther('7')
+        )
+      ).to.be.revertedWith('Reward token cannot be pair');
+    });
   });
 
   describe('Staking', function () {
@@ -725,6 +736,30 @@ describe('LPStaking', function () {
       expect(tx).to.emit(lpStaking, 'RewardsClaimed').withArgs(freshUser.address, lpTokenAddress);
     });
 
+    it('Should accrue sub-hourly precision for small hourly reward rates', async function () {
+      const tinyHourlyReward = 3599n;
+      const receipt = await (await lpStaking.proposeSetHourlyRewardRate(tinyHourlyReward)).wait();
+      const event = receipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const actionId = (event as any)?.args?.actionId;
+
+      await lpStaking.connect(signers[0]).approveAction(actionId);
+      await lpStaking.connect(signers[1]).approveAction(actionId);
+      await lpStaking.executeAction(actionId);
+
+      await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
+
+      await ethers.provider.send('evm_increaseTime', [3600]);
+      await ethers.provider.send('evm_mine', []);
+
+      const initialBalance = await rewardToken.balanceOf(user1.address);
+      await lpStaking.connect(user1).claimRewards(lpTokenAddress);
+      const finalBalance = await rewardToken.balanceOf(user1.address);
+
+      const rewardsEarned = finalBalance - initialBalance;
+      expect(rewardsEarned).to.be.gt(0);
+      expect(rewardsEarned).to.be.lte(tinyHourlyReward + 1n);
+    });
+
     it('Should reset reward accumulators when a fully removed pair is re-added', async function () {
       await lpStaking.connect(user1).stake(lpTokenAddress, STAKE_AMOUNT);
 
@@ -876,6 +911,42 @@ describe('LPStaking', function () {
 
         const balance = await rewardToken.balanceOf(signers[1].address);
         expect(balance).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should clean up expired actions by bounded range', async function () {
+      const firstReceipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE)).wait();
+      const firstEvent = firstReceipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const firstActionId = (firstEvent as any)?.args?.actionId;
+
+      const secondReceipt = await (await lpStaking.proposeSetHourlyRewardRate(NEW_RATE + 1n)).wait();
+      const secondEvent = secondReceipt?.logs?.find((e: any) => e.fragment.name === 'ActionProposed');
+      const secondActionId = (secondEvent as any)?.args?.actionId;
+
+      await ethers.provider.send('evm_increaseTime', [7 * 24 * 60 * 60 + 1]);
+      await ethers.provider.send('evm_mine', []);
+
+      await lpStaking.cleanupExpiredActions(firstActionId, firstActionId);
+
+      let firstAction = await lpStaking.actions(firstActionId);
+      let secondAction = await lpStaking.actions(secondActionId);
+      expect(firstAction.expired).to.be.true;
+      expect(secondAction.expired).to.be.false;
+
+      await lpStaking.cleanupExpiredActions(secondActionId, secondActionId);
+
+      secondAction = await lpStaking.actions(secondActionId);
+      expect(secondAction.expired).to.be.true;
+    });
+
+    it('Should reject invalid expired-action cleanup ranges', async function () {
+      await lpStaking.proposeSetHourlyRewardRate(NEW_RATE);
+
+      await expect(lpStaking.cleanupExpiredActions(0, 1))
+        .to.be.revertedWith('Invalid start');
+      await expect(lpStaking.cleanupExpiredActions(1, 0))
+        .to.be.revertedWith('Invalid range');
+      await expect(lpStaking.cleanupExpiredActions(1, 2))
+        .to.be.revertedWith('Invalid end');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds the remaining low-risk cleanup and guard fixes on top of the pair lifecycle stack.

## Changes

- Rejects adding the reward token itself as an LP staking pair.
- Re-checks that same reward-token guard during `ADD_PAIR` execution.
- Replaces unbounded `cleanupExpiredActions()` with paginated `cleanupExpiredActions(start, end)`.
- Improves reward precision by calculating elapsed rewards before dividing by `SECONDS_PER_HOUR`, using OpenZeppelin `Math.mulDiv`.
- Removes the unused internal `updateRewards()` helper.
- Adds regression tests for reward-token pair rejection, bounded cleanup ranges, invalid cleanup ranges, and sub-hourly reward precision.

## Why

These address the remaining cleanup findings from the audit set: bad pair guardrails, unbounded admin cleanup loops, divide-before-multiply precision loss, and dead code.

## Stacked PR Note

This PR intentionally targets `codex/pair-lifecycle-after-accounting`. Merge order should be:

1. #16 internal staking accounting
2. #17 pair lifecycle cleanup
3. this PR

## Validation

- `npx hardhat compile`
- `npx hardhat test --network hardhat`